### PR TITLE
add support for bun

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@ This is a plugin that will lazy load [nvm](https://github.com/nvm-sh/nvm).
 
 Running `nvm.sh` in your `.zshrc` can significantly slow down startup time. This plugin is designed to mitigate that issue.
 
-The commands `nvm`, `node`, `yarn`, `pnpm`, `npm`, and `npx` will load `nvm.sh` upon their first invocation, thereby avoiding any startup time penalty for shells that aren't going to use them at all.
+The commands `nvm`, `node`, `yarn`, `pnpm`, `npm`, `npx`, and `bun` will load `nvm.sh` upon their first invocation, thereby avoiding any startup time penalty for shells that aren't going to use them at all.
 
 There is only a single time penalty for the shell. After the first time you run any of the commands above, `nvm` will already be initialized, so there will be no additional delay.

--- a/zsh-nvm-lazy-load.plugin.zsh
+++ b/zsh-nvm-lazy-load.plugin.zsh
@@ -46,3 +46,8 @@ yarn() {
     yarn "$@"
 }
 
+bun() {
+    unset -f bun
+    load-nvm
+    bun "$@"
+}


### PR DESCRIPTION
Issues can occur when trying to use Bun in some projects when Node is not initialised, particularly where it is only being used as a package manager.