### PR TITLE
fix a bug that cause nvm.sh running multiple times

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@ This is a plugin that will lazy load [nvm](https://github.com/nvm-sh/nvm).
 
 Running `nvm.sh` in your `.zshrc` can significantly slow down startup time. This plugin is designed to mitigate that issue.
 
-The commands `nvm`, `node`, `npm`, `npx`, `pnpm`, `yarn`, `pnpx`, and `bun` will load `nvm.sh` upon their first invocation, thereby avoiding any startup time penalty for shells that aren't going to use them at all.
+The commands `nvm`, `node`, `npm`, `npx`, `pnpm`, `yarn`, `pnpx`, `bun`, and `bunx` will load `nvm.sh` upon their first invocation, thereby avoiding any startup time penalty for shells that aren't going to use them at all.
 
 There is only a single time penalty for the shell. After the first time you run any of the commands above, `nvm` will already be initialized, so there will be no additional delay.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@ This is a plugin that will lazy load [nvm](https://github.com/nvm-sh/nvm).
 
 Running `nvm.sh` in your `.zshrc` can significantly slow down startup time. This plugin is designed to mitigate that issue.
 
-The commands `nvm`, `node`, `yarn`, `pnpm`, `npm`, and `npx` will load `nvm.sh` upon their first invocation, thereby avoiding any startup time penalty for shells that aren't going to use them at all.
+The commands `nvm`, `node`, `npm`, `npx`, `pnpm`, `yarn`, `pnpx`, and `bun` will load `nvm.sh` upon their first invocation, thereby avoiding any startup time penalty for shells that aren't going to use them at all.
 
 There is only a single time penalty for the shell. After the first time you run any of the commands above, `nvm` will already be initialized, so there will be no additional delay.

--- a/zsh-nvm-lazy-load.plugin.zsh
+++ b/zsh-nvm-lazy-load.plugin.zsh
@@ -5,44 +5,30 @@
 # posing no start up time penalty for the shells that aren't going to use them at all.
 # There is only single time penalty for one shell.
 
+typeset -ga lazyLoadLabels=(nvm node npm npx pnpm yarn pnpx)
+
+set-labels() {
+    for label in "${lazyLoadLabels[@]}"; do
+        eval "$label() { work; command $label \"\$@\"; }"
+    done
+}
+
+remove-all-lazyLoadLabels() {
+    for label in $lazyLoadLabels; do
+        unset -f $label
+    done
+    unset -v lazyLoadLabels
+}
+
 load-nvm() {
     export NVM_DIR=~/.nvm
     [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" # This loads nvm
+    [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
 }
 
-nvm() {
-    unset -f nvm
+work() {
     load-nvm
-    nvm "$@"
+    remove-all-lazyLoadLabels
 }
 
-node() {
-    unset -f node
-    load-nvm
-    node "$@"
-}
-
-npm() {
-    unset -f npm
-    load-nvm
-    npm "$@"
-}
-
-npx() {
-    unset -f npx
-    load-nvm
-    npx "$@"
-}
-
-pnpm() {
-    unset -f pnpm
-    load-nvm
-    pnpm "$@"
-}
-
-yarn() {
-    unset -f yarn
-    load-nvm
-    yarn "$@"
-}
-
+set-labels

--- a/zsh-nvm-lazy-load.plugin.zsh
+++ b/zsh-nvm-lazy-load.plugin.zsh
@@ -5,7 +5,7 @@
 # posing no start up time penalty for the shells that aren't going to use them at all.
 # There is only single time penalty for one shell.
 
-typeset -ga lazyLoadLabels=(nvm node npm npx pnpm yarn pnpx)
+typeset -ga lazyLoadLabels=(nvm node npm npx pnpm yarn pnpx bun)
 
 set-labels() {
     for label in "${lazyLoadLabels[@]}"; do

--- a/zsh-nvm-lazy-load.plugin.zsh
+++ b/zsh-nvm-lazy-load.plugin.zsh
@@ -5,7 +5,7 @@
 # posing no start up time penalty for the shells that aren't going to use them at all.
 # There is only single time penalty for one shell.
 
-typeset -ga lazyLoadLabels=(nvm node npm npx pnpm yarn pnpx bun)
+typeset -ga lazyLoadLabels=(nvm node npm npx pnpm yarn pnpx bun bunx)
 
 set-labels() {
     for label in "${lazyLoadLabels[@]}"; do


### PR DESCRIPTION
In old version, if you type **npm** then **yarn** for example, the nvm.sh will run twice. Fixed this bug and have some refactor